### PR TITLE
Add the mongo cluster installation

### DIFF
--- a/cloudbuild-vm.yaml
+++ b/cloudbuild-vm.yaml
@@ -20,8 +20,6 @@
 # _SOLUTION_NAME - <VM IMAGE TO BE BUILT>
 
 timeout: 1800s # 30m
-options:
-  workerPool: ${PROJECT_ID}/gcb-workers-pool
 steps:
 
 - id: Download Service Account Key
@@ -59,8 +57,8 @@ steps:
   - --env=RUN_TESTS=true
   - --env=ATTACH_LICENSE=true
   - --env=LICENSE_PROJECT_NAME=click-to-deploy-images
-  - --env=USE_INTERNAL_IP=true
   - --env=TESTS_CUSTOM_METADATA=google-c2d-startup-enable=0
+  - --env=ZONE=asia-east1-a
   - --volume=/workspace/vm/chef:/chef:ro
   - --volume=/workspace/vm/packer:/packer:ro
   - --volume=/workspace/vm/tests:/tests:ro

--- a/vm/chef/cookbooks/mongodb/attributes/default.rb
+++ b/vm/chef/cookbooks/mongodb/attributes/default.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 default['mongodb']['debian']['codename'] = 'stretch'
-default['mongodb']['version'] = '4.0.0'
+default['mongodb']['version'] = '3.6.18'
 default['mongodb']['release'] =
   default['mongodb']['version'].split('.').take(2).join('.')
 

--- a/vm/chef/cookbooks/mongodb/files/conf/mongodb.logger.conf
+++ b/vm/chef/cookbooks/mongodb/files/conf/mongodb.logger.conf
@@ -1,0 +1,19 @@
+<source>
+  @type tail
+  <parse>
+    @type regexp
+    expression /(?<time>[^\n ]+)\s(?<severity>[A-Z])\s(?<component>[A-Z]+)\s+?\[?(?<context>[a-zA-Z0-9]+)]\s(?<message>[^\n]+)/
+    time_format %Y-%m-%dT%H:%M:%S.%L%z
+  </parse>
+  path /var/log/mongodb/mongod.log
+  pos_file /var/lib/google-fluentd/pos/mongodb.pos
+  read_from_head true
+  tag mongodb
+</source>
+<filter mongodb>
+  @type record_transformer
+  enable_ruby
+  <record>
+    severity ${if record["severity"] == "I" then "INFO" elsif record["severity"] == "W" then "WARNING" elsif record["severity"] == "F" || record["severity"] == "E" then "ERROR" else "DEBUG" end}
+  </record>
+</filter>

--- a/vm/chef/cookbooks/mongodb/files/conf/mongodb.monitor.conf
+++ b/vm/chef/cookbooks/mongodb/files/conf/mongodb.monitor.conf
@@ -1,0 +1,17 @@
+# This is the monitoring configuration for MongoDB.
+# Look for STATS_USER, STATS_PASS, MONGODB_HOST and MONGODB_PORT to adjust your configuration file.
+LoadPlugin mongodb
+<Plugin "mongodb">
+    # When using non-standard MongoDB configurations, replace the below with
+    #Host "MONGODB_HOST"
+    #Port "MONGODB_PORT"
+    Host "localhost"
+    Port "27017"
+
+    # If you restricted access to the database, you can set the username and
+    # password here:
+    #User "STATS_USER"
+    #Password "STATS_PASS"
+    User "${STATS_USER}"
+    Password "${STATS_PASS}"
+</Plugin>

--- a/vm/chef/cookbooks/mongodb/files/startup/mongodb-logger
+++ b/vm/chef/cookbooks/mongodb/files/startup/mongodb-logger
@@ -1,0 +1,37 @@
+#!/bin/bash -eu
+#
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script assumes that mongodb has already been installed and that
+# a bare-bones service is running on each of the members of the cluster.
+#
+# The script will:
+#   * Set up custom logger:
+#     * Add configuration for stackdriver logging
+
+systemctl is-active --quiet google-fluentd
+
+# Check if google-fluentd is available
+status=$?
+if [ $status -eq 1 ]; then
+  echo "Google-fluentd service is not running. Skip."
+  rm /etc/mongodb.logger.conf
+  exit 0
+fi
+
+# Overwrite mongodb.conf of fluentd-catch-all-config
+mv /etc/mongodb.logger.conf /etc/google-fluentd/config.d/mongodb.conf
+
+service google-fluentd restart

--- a/vm/chef/cookbooks/mongodb/files/startup/mongodb-monitor
+++ b/vm/chef/cookbooks/mongodb/files/startup/mongodb-monitor
@@ -1,0 +1,80 @@
+#!/bin/bash -eu
+#
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script assumes that mongodb has already been installed and that
+# a bare-bones service is running on each of the members of the cluster.
+#
+# The script will:
+#   * Set up cluster monitor:
+#     * Add configuration for monitor
+#     * Create an user with cluster monitor role 
+
+source /opt/c2d/c2d-utils || exit 1
+
+systemctl is-active --quiet stackdriver-agent
+
+# Check if stackdriver-agent is available
+status=$?
+if [ $status -eq 1 ]; then
+  echo "Stackdriver-agent service is not running. Skip."
+  exit 0
+fi
+
+# Build mongo monitor config from template
+readonly STACKDRIVER_CONF_PATH="/etc/stackdriver/collectd.d"
+readonly TEMPLATE="mongodb.monitor.conf.template"
+
+cd $STACKDRIVER_CONF_PATH
+
+# Configure stackdirver monitoring user and password
+export STATS_USER=stackdriver
+export STATS_PASS=$(get_attribute_value "stackdriver_password")
+
+mv /etc/$TEMPLATE $STACKDRIVER_CONF_PATH 
+
+envsubst < $TEMPLATE > mongodb.conf
+rm $TEMPLATE
+
+echo "Mongodb monitoring script is installed"
+
+service stackdriver-agent restart
+
+# First instance in the list will be the mongodb_primary_instance
+readonly mongodb_instances="$(get_attribute_value "mongodb_servers")"
+readonly mongodb_primary_instance="$(echo "${mongodb_instances}" \
+  | awk '{ print $1 }')"
+
+# Create the monitor user only from primary
+if [[ "$(hostname)" != "${mongodb_primary_instance}" ]]; then
+  echo "Not primary. Exiting"
+  exit 0
+fi
+
+# Create monitor user
+cat << EOF > /tmp/createuser
+db.createUser(
+   {
+     user: "$STATS_USER",
+     pwd: "$STATS_PASS",
+     roles: [ { role: "clusterMonitor", db: "admin" } ]
+   }
+)
+EOF
+
+mongo admin < /tmp/createuser
+rm /tmp/createuser
+
+echo "Stackdriver monitor user created"

--- a/vm/chef/cookbooks/mongodb/recipes/default.rb
+++ b/vm/chef/cookbooks/mongodb/recipes/default.rb
@@ -68,6 +68,14 @@ cookbook_file '/etc/mongod.serv.conf.template' do
   action :create
 end
 
+cookbook_file '/etc/mongodb.monitor.conf.template' do
+  source 'conf/mongodb.monitor.conf'
+  owner 'root'
+  group 'root'
+  mode 0644
+  action :create
+end
+
 c2d_startup_script 'mongodb-server' do
   source 'startup/mongodb-server'
 end
@@ -78,6 +86,10 @@ end
 
 c2d_startup_script 'mongodb-validator' do
   source 'startup/mongodb-validator'
+end
+
+c2d_startup_script 'mongodb-monitor' do
+  source 'startup/mongodb-monitor'
 end
 
 # Prepare directory for sources and licenses

--- a/vm/chef/cookbooks/mongodb/recipes/default.rb
+++ b/vm/chef/cookbooks/mongodb/recipes/default.rb
@@ -76,6 +76,15 @@ cookbook_file '/etc/mongodb.monitor.conf.template' do
   action :create
 end
 
+cookbook_file '/etc/mongodb.logger.conf' do
+  source 'conf/mongodb.logger.conf'
+  owner 'root'
+  group 'root'
+  mode 0644
+  action :create
+end
+
+
 c2d_startup_script 'mongodb-server' do
   source 'startup/mongodb-server'
 end
@@ -90,6 +99,10 @@ end
 
 c2d_startup_script 'mongodb-monitor' do
   source 'startup/mongodb-monitor'
+end
+
+c2d_startup_script 'mongodb-logger' do
+  source 'startup/mongodb-logger'
 end
 
 # Prepare directory for sources and licenses

--- a/vm/packer/templates/mongodb/packer.in.json
+++ b/vm/packer/templates/mongodb/packer.in.json
@@ -2,6 +2,6 @@
   "license": "c2d-mongodb",
   "source_image_family": "debian-9",
   "chef": {
-    "run_list": [ "c2d-config", "mongodb" ]
+    "run_list": [ "c2d-config", "mongodb", "stackdriver" ]
   }
 }

--- a/vm/tests/solutions/spec/mongodb/stackdriver_spec.rb
+++ b/vm/tests/solutions/spec/mongodb/stackdriver_spec.rb
@@ -1,1 +1,1 @@
-../__common__/stackdriver_not_installed.rb
+../__common__/stackdriver_installed.rb


### PR DESCRIPTION
# Why Change
V1 mongo cluster setup has following drawbacks.
* Lack of logging entries of the mongo cluster on stackdriver
* Lack of metrics of the mongo cluster on stackdriver monitoring
* Obscure VM image from marketplace adds maintenance cost

# What does the PR do
* Extend the VM image build steps for twreporter mongo cluster
  * Install the required Stackdriver-agent for logging and monitoring
  * Setup monitoring configuration of collectd for Stackdriver-agent
  * Setup customized configuration of fluentd for Stackdriver logging
  * Build the VM image from base OS image to control the package dependencies for future reference

# Solution Overview
The click-to-deploy repo contains the source lists of solutions on Google Cloud Platform Marketplace which provision applications on containers(K8S) or VM(GCE) with one click. We mainly focus on the solution of mongo cluster by vm instances.

vm directory contains the following components: 
* Configuration Management (chef)
* VM image builder(packer) 
* Validation scripts (tests)

## Configuration Management
The chef directory contains the build time configuration and provisioning startup scripts described in [cookbooks](https://docs.chef.io/chef_solo/#cookbooks). Brief descriptions of the subdirectories of the solution are listed below.
* attributes directory:
    * Descirbe the  metadata of the main application (e.g, mongo) and other dependencies
* files directory:
    * Contain configuration templates and runtime startup scripts
* recipes directory:
    * Describe the vm image installation steps 

## VM image builder
The packer directory contains the configuration for [Packer](https://www.packer.io/) to build the system image. The packer utilize [chef-solo provisioner](https://www.packer.io/docs/provisioners/chef-solo) to descirbe the target solutions and the installation order(run-list).

## Cloud Build
The repo utilizes [prebuilt docker image](https://github.com/GoogleCloudPlatform/marketplace-vm-imagebuilder/blob/master/Dockerfile) to build the vm image as described in the cloudbuild-vm.yaml on cloud-build. This prebuilt image comes with the required applications(packer, chef-solo) to run the configuration within Packer and Chef directories. After the target image is built, it will provision a disposable compute instance to run the tests against the image.

Build image 
```
GCP_PROJECT_TO_RUN_CLOUD_BUILD=[PROJECT_ID] \
PACKER_LOGS_GCS_BUCKET_NAME=[LOGS_BUCKET] \
SERVICE_ACCOUNT_KEY_JSON_GCS=[SERVICE_ACCOUNT_ON_GCS] \
SOLUTION_NAME=[TARGET_NAME] make cloud-build-vm
```

# Image Usage
Select the image during the GCE creation and create extra attached disk for the mongo data persistent. Note that the attached-disk should be named with `[instance hostname]-data`.
```
hostname: mongo-test-server
attached-disk: mongo-test-server-data
```

Also, configure following metadata on the instance
```
is_mongodb_server "True" // whether this instance of the cluster persists data
is_mongodb_arbiter "False" // whether this instance of the cluster is arbiter
mongodb_replicaset_name "rs0" // replicaset name of mongo cluster
mongodb_servers "MONGO_SERVER_1 MONGO_SERVER_2 MONGO_SERVER_3" // instances list of the mongo group
stackdriver_password "admin_password" // password for monitor user
```